### PR TITLE
Fix error on failed XML cast for DNS servers.

### DIFF
--- a/AutomatedDeployments/AD/CreateVNet.ps1
+++ b/AutomatedDeployments/AD/CreateVNet.ps1
@@ -101,7 +101,7 @@ function CreateVNet()
 		$combinedVNetConfig = $currentVNetConfig
 		
 		#Combine DNS Servers
-		$dnsNode = $combinedVNetConfig.NetworkConfiguration.VirtualNetworkConfiguration.Dns
+		$dnsNode = [xml] $combinedVNetConfig.NetworkConfiguration.VirtualNetworkConfiguration.Dns
 		if($dnsNode -ne $null)
 		{
 			$inputDnsServers = $inputVNetConfig.NetworkConfiguration.VirtualNetworkConfiguration.Dns.DnsServers


### PR DESCRIPTION
Resolves issue reported on blog at http://blogs.msdn.com/b/windowsazure/archive/2013/05/24/automating-sharepoint-deployments-in-windows-azure-using-powershell.aspx where user reported that ReplaceChild wasn't working as resulted in an error.
