### PR TITLE
Fixed SQL Server 2012 ImageFamily

### DIFF
--- a/AutomatedDeployments/SharedComponents/autoconfigure.ps1
+++ b/AutomatedDeployments/SharedComponents/autoconfigure.ps1
@@ -191,7 +191,7 @@ function SetADConfiguration
 function SetSQLConfiguration
 {
     param($configPath,$serviceName,$storageAccount,$subscription, $adminAccount, $password, $domain, $dnsDomain)
-    $sql2k12img = (GetLatestImage "SQL Server 2012 SP1 Enterprise On Win2K8R2")
+    $sql2k12img = (GetLatestImage "SQL Server 2012 SP1 Enterprise on WS 2008 R2")
     $configPathAutoGen = $configPath.Replace(".xml", "-AutoGen.xml")
     [xml] $config = gc $configPath
     $config.Azure.SubscriptionName = $subscription 


### PR DESCRIPTION
Fixed the SQL Server 2012 ImageFamily name to match the currently available Azure image name. Apparently Microsoft changed some names, so the script broke.
