### PR TITLE
Correct typo for .cloudapp.net in Admin Site link

### DIFF
--- a/AutomatedDeployments/SharedComponents/autoconfigure.ps1
+++ b/AutomatedDeployments/SharedComponents/autoconfigure.ps1
@@ -152,7 +152,7 @@ Function AutoConfigure
         {
             Write-Host "Credentials: $domain\$adminAccount Password: $adminPassword"
             Write-Host "Created Farm on http://$serviceName.cloudapp.net"
-            Write-Host "Created Admin Site on http://$serviceName.clouadpp.net:20000"
+            Write-Host "Created Admin Site on http://$serviceName.cloudapp.net:20000"
         }
     }
     else


### PR DESCRIPTION
cloudapp.net was misspelled as clouadpp.net.   This was showing up at the very end of the script when it was listing the links to the site and Central Admin.  The link for Central Admin had the typo, the site link was correct.
